### PR TITLE
Fix typo in example .env file (#511)

### DIFF
--- a/services/enterprise/.env.example
+++ b/services/enterprise/.env.example
@@ -10,7 +10,7 @@ AUTH0_ISSUER_BASE_URL= # your auth0 issuer url, i.e.: https://auth.dataherald.co
 AUTH0_API_AUDIENCE= # your auth0 API audience, i.e.: https://dataherald.us.auth0.com/api/v2/
 # AUTH0_DISABLED creates a mock authentication token type for testing purposes
 # you can provide an email as the bearer token, note that the admin console will not be able to authenticate
-AUTH0_DISABED=False
+AUTH0_DISABLED=False
 
 # The salt is used to hash the API key, use the string from ENCRYPT_KEY or create a different one
 API_KEY_SALT=

--- a/services/enterprise/README.md
+++ b/services/enterprise/README.md
@@ -35,7 +35,7 @@ To connect to Auth0 you will need to fill in the following environment variables
 AUTH0_DOMAIN=
 AUTH0_ISSUER_BASE_URL=
 AUTH0_API_AUDIENCE=
-AUTH0_DISABED=False
+AUTH0_DISABLED=False
 ```
 
 Please, read the front-end docs about Auth0 [here](../admin-console/README.md#setting-up-an-auth0-application) if you have troubles setting this up.


### PR DESCRIPTION
pulled from upstream main